### PR TITLE
The defaults include only HEAD, GET, and POST; why restrict it?

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,9 @@
   );
 
   cors = xcors();
-  session = corsSession();
+  session = corsSession({
+    methods: ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+  });
   connect.addMiddleware(
       nowww()
     , connect.query()


### PR DESCRIPTION
I can't think of a reason to only allow the defaults supplied by the module. I ran into a problem where `DELETE` wasn't being handled cross-origin, which seemed stupid to me.
